### PR TITLE
Added `unpackeclipse` exec to the file method

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,6 +101,14 @@ define eclipse(
 			source => $filesource;
 		}
 			
+		exec {"upackeclipse":
+		    command=>$unpackcommand,
+		    cwd=> $eclipse::params::executefrom,
+		    path=> $eclipse::params::execlaunchpaths,
+		    creates=>$finalcreates,
+		    logoutput=> on_failure,
+		    require=>File["eclipsefile"]
+		}
 		# Mod eclipse
 		exec {"modeclipse":
 			command=>$modeclipse,


### PR DESCRIPTION
Hi,

I have created a fix for this issue #9. I tested it with this snippet:

```
eclipse { 'install_eclipse':
        method          => 'file',
        filesource      => "/data0/files/eclipse/${eclipse_archive_file}",
        downloadfile    => "${eclipse_archive_file}",
}
```

... which runs with no errors.
